### PR TITLE
Change `coords` to `dims`

### DIFF
--- a/pages/gallery/Declarative_300hPa.ipynb
+++ b/pages/gallery/Declarative_300hPa.ipynb
@@ -94,7 +94,7 @@
     "wspd = mpcalc.wind_speed(uwnd, vwnd)\n",
     "\n",
     "# Place wind speed (wspd) into xarray dataset and attach needed attributes\n",
-    "ds = ds.assign(wind_speed=(tuple(uwnd.coords)[:4], wspd.m,\n",
+    "ds = ds.assign(wind_speed=(tuple(uwnd.dims)[:4], wspd.m,\n",
     "                           {'grid_mapping': uwnd.attrs['grid_mapping'],\n",
     "                            'units': str(wspd.units)}))\n",
     "\n",


### PR DESCRIPTION
In adapting this code snippet to another example tonight, I discovered that DataArray.coords does not guarantee the same order as dims, resulting in a dimension mismatch when assigning. Changing to DataArray.dims fixed the issue for me.