### PR TITLE
MNT: fix inverted y-axis

### DIFF
--- a/pages/gallery/Observational_Data_Cross_Section.ipynb
+++ b/pages/gallery/Observational_Data_Cross_Section.ipynb
@@ -355,7 +355,7 @@
     "ax.set_yticklabels(range(1000, 101, -100))\n",
     "\n",
     "# Invert the y-axis since pressure decreases with increasing height\n",
-    "ax.invert_yaxis()\n",
+    "ax.yaxis_inverted()\n",
     "\n",
     "# Plot the sudo elevation on the cross section\n",
     "ax.fill_between(xsect['obs_distance'], xsect['elevation'].m, 1030,\n",
@@ -390,6 +390,13 @@
     "\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -397,8 +404,25 @@
    "cell_metadata_filter": "-all",
    "main_language": "python",
    "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In reviewing the new training site (and I think this is true on the old site as well), the y-axis was no longer being inverted with the line

```ax.invert_yaxis()```

This is now changed to 

```ax.yaxis_inverted()```

and all is correct with getting the highest pressures at the bottom of the figure.