### PR TITLE
add lookup for level dimname

### DIFF
--- a/pages/workshop/Model_Output/Downloading model fields with NCSS.ipynb
+++ b/pages/workshop/Model_Output/Downloading model fields with NCSS.ipynb
@@ -80,8 +80,7 @@
    "metadata": {
     "pycharm": {
      "is_executing": false
-    },
-    "scrolled": false
+    }
    },
    "outputs": [],
    "source": [
@@ -395,7 +394,8 @@
     "\n",
     "# get netCDF variables\n",
     "pressure = point_data.variables[\"isobaric\"]\n",
-    "lev_temp = point_data.variables[\"isobaric4\"]\n",
+    "dname_temp = point_data.variables[\"Temperature_isobaric\"].dimensions[2]\n",
+    "lev_temp = point_data.variables[dname_temp]\n",
     "temp = point_data.variables[\"Temperature_isobaric\"]\n",
     "u_cmp = point_data.variables[\"u-component_of_wind_isobaric\"]\n",
     "v_cmp = point_data.variables[\"v-component_of_wind_isobaric\"]\n",
@@ -490,6 +490,13 @@
     "skew.plot_moist_adiabats()\n",
     "skew.plot_mixing_lines()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -522,5 +529,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
One of the errors that is coming up in the build of the training site is when the vertical dimension name changes because of grib conventions. Such that it is not always isobaric4. I've added a variable that stores the needed dimension name to not have this error come up on occasion.