### PR TITLE
add sat-surface declare overlay example

### DIFF
--- a/pages/gallery/satellite_sfc_obs.ipynb
+++ b/pages/gallery/satellite_sfc_obs.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Satellite and Surface Obs\n",
+    "\n",
+    "By: Kevin Goebbert\n",
+    "\n",
+    "Combining both satellite and surface observations is easy with the simplified declarative syntax available in MetPy. This example uses a bit of Siphon to help get current observations and satellite retrievals.\n",
+    "\n",
+    "As demonstrated at AMS 2020 Annual Meeting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timedelta\n",
+    "\n",
+    "from metpy.io import metar\n",
+    "from metpy.plots.declarative import *\n",
+    "from metpy.units import units\n",
+    "import numpy as np\n",
+    "from siphon.catalog import TDSCatalog\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A nice definition to help get the most recent satellite observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_goes_image(date=datetime.utcnow(), channel=8, region='CONUS'):\n",
+    "    \"\"\"Return dataset of GOES-16 data.\"\"\"\n",
+    "    cat = TDSCatalog('https://thredds.ucar.edu/thredds/catalog/satellite/goes/east/products/'\n",
+    "                     'CloudAndMoistureImagery/{}/Channel{:02d}/{:%Y%m%d}/'\n",
+    "                     'catalog.xml'.format(region, channel, date))\n",
+    "\n",
+    "    # Get data from about an hour ago.\n",
+    "    if len(list(cat.datasets)) < 10:\n",
+    "        file_num = len(list(cat.datasets))\n",
+    "    else:\n",
+    "        file_num = 10\n",
+    "    ds = cat.datasets[file_num]  # Get most recent dataset\n",
+    "    ds = ds.remote_access(use_xarray=True)\n",
+    "    return ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Satellite data\n",
+    "\n",
+    "Use data available on the UCAR THREDDS Data Server to get a recent GOES East IR satellite imagery from Channel 14."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get IR Satellite data\n",
+    "ds = get_goes_image(datetime.utcnow(), channel=14)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set map time from Satellite Data\n",
+    "vtime = ds.time.values.astype('datetime64[ms]').astype('O')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get METAR Observations\n",
+    "\n",
+    "Use available METAR data, also obtained from the UCAR THREDDS Data Server, download and parse using the MetPy METAR parsing functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Surface Data from UCAR\n",
+    "cat = TDSCatalog('https://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/metar/catalog.xml')\n",
+    "\n",
+    "time_idx = list(cat.datasets).index(f'metar_{vtime:%Y%m%d}_{vtime:%H}00.txt')\n",
+    "\n",
+    "metar_df = cat.datasets[time_idx]\n",
+    "metar_df.download()\n",
+    "\n",
+    "# Parse METAR data with MetPy\n",
+    "df = metar.parse_metar_file(metar_df.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert Variable\n",
+    "\n",
+    "Typically we plot surface temperature in the Fahrenheit scale in the U.S., so we are going to use MetPy unit functionarlity to convert the METAR air temperature (which is in Celsuius) to Fahrenheit and add it to the dataFrame. Subset data to be only over CONUS to help with plotting obs on the satellite projection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert temperature to degF and store in dataframe\n",
+    "df['tmpf'] = (df.air_temperature.values * units(df.units['air_temperature'])).to('degF')\n",
+    "\n",
+    "# Subset for data only over CONUS (for plotting ease)\n",
+    "df = df[(df.latitude.values > 25) & (df.latitude.values < 60)]\n",
+    "df = df[(df.longitude.values < -60) & (df.longitude.values > -150)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Plot\n",
+    "\n",
+    "Use the declarative syntax from MetPy to plot both the METAR surface temperatures and the GOES EAST IR Satellite Imagery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Plot\n",
+    "\n",
+    "# Plot all obs greater than 32F red\n",
+    "obs = PlotObs()\n",
+    "obs.data = df[df.tmpf > 32]\n",
+    "obs.time = vtime\n",
+    "obs.time_window = timedelta(minutes=30)\n",
+    "obs.level = None\n",
+    "obs.fields = ['tmpf']\n",
+    "obs.colors = ['red']\n",
+    "obs.reduce_points = 0.7\n",
+    "\n",
+    "# Plot all obs less than 32F blue\n",
+    "obs2 = PlotObs()\n",
+    "obs2.data = df[df.tmpf <= 32]\n",
+    "obs2.time = vtime\n",
+    "obs2.time_window = timedelta(minutes=30)\n",
+    "obs2.level = None\n",
+    "obs2.fields = ['tmpf']\n",
+    "obs2.colors = ['blue']\n",
+    "obs2.reduce_points = 0.7\n",
+    "\n",
+    "# Add the IR image to the plot\n",
+    "img = ImagePlot()\n",
+    "img.data = ds\n",
+    "img.field = 'Sectorized_CMI'\n",
+    "img.colormap = 'Greys'\n",
+    "\n",
+    "# Bring plots together in a map panel and add a title\n",
+    "panel = MapPanel()\n",
+    "panel.area = [-112, -65, 20, 50]\n",
+    "panel.title = f'IR Satellite Data Channel 14 with Surface Temperature (F) at {vtime}'\n",
+    "panel.layers = ['coastline', 'borders', 'states']\n",
+    "panel.plots = [img, obs, obs2]\n",
+    "\n",
+    "# Place the panel on a figure\n",
+    "pc = PanelContainer()\n",
+    "pc.size = (20, 20)\n",
+    "pc.panels = [panel]\n",
+    "pc.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This is one of the examples that I demonstrated at the AMS 2020 Annual meeting; adding it to the gallery as an easy example of overlaying satellite imagery with surface temperatures from METAR data.