### PR TITLE
Update NCEP TDS data access URLs

### DIFF
--- a/pages/gallery/500hPa_Vorticity_Advection.ipynb
+++ b/pages/gallery/500hPa_Vorticity_Advection.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "# Open the example netCDF data\n",
-    "ncss = NCSS('https://www.ncei.noaa.gov/thredds/ncss/grid/namanl/'\n",
+    "ncss = NCSS('https://www.ncdc.noaa.gov/thredds/ncss//namanl/'\n",
     "            '201604/20160416/namanl_218_20160416_1800_000.grb')\n",
     "now = datetime.utcnow()\n",
     "\n",

--- a/pages/gallery/850hPa_Temperature_Advection.ipynb
+++ b/pages/gallery/850hPa_Temperature_Advection.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_url = 'https://www.ncei.noaa.gov/thredds/ncss/grid/gfs-g4-anl-files/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/ncss//gfs-g4-anl-files/'\n",
     "dt = datetime(2017, 4, 5, 12)\n",
     "ncss = NCSS('{}{dt:%Y%m}/{dt:%Y%m%d}/gfsanl_4_{dt:%Y%m%d}_'\n",
     "            '{dt:%H}00_000.grb2'.format(base_url, dt=dt))\n",

--- a/pages/gallery/Ageostrophic_Wind_Example.ipynb
+++ b/pages/gallery/Ageostrophic_Wind_Example.ipynb
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "# Create NCSS object to access the NetcdfSubset\n",
-    "base_url = 'https://www.ncei.noaa.gov/thredds/ncss/grid/gfs-g4-anl-files/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/ncss//gfs-g4-anl-files/'\n",
     "dt = datetime(2016, 8, 22, 18)\n",
     "ncss = NCSS('{}{dt:%Y%m}/{dt:%Y%m%d}/gfsanl_4_{dt:%Y%m%d}_'\n",
     "            '{dt:%H}00_003.grb2'.format(base_url, dt=dt))\n",

--- a/pages/gallery/HILO_Symbol_Plot.ipynb
+++ b/pages/gallery/HILO_Symbol_Plot.ipynb
@@ -118,7 +118,7 @@
    "source": [
     "dattim = datetime(1999, 1, 3, 0)\n",
     "\n",
-    "ncss = NCSS('https://www.ncei.noaa.gov/thredds/ncss/grid/narr-a-files/{0:%Y%m}/{0:%Y%m%d}/'\n",
+    "ncss = NCSS('https://www.ncdc.noaa.gov/thredds/ncss//narr-a-files/{0:%Y%m}/{0:%Y%m%d}/'\n",
     "            'narr-a_221_{0:%Y%m%d}_{0:%H}00_000.grb'.format(dattim))\n",
     "query = ncss.query()\n",
     "query.all_times().variables('Pressure_reduced_to_MSL_msl',\n",

--- a/pages/gallery/MSLP_temp_winds.ipynb
+++ b/pages/gallery/MSLP_temp_winds.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_url = 'https://www.ncei.noaa.gov/thredds/ncss/grid/gfs-g4-anl-files/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/ncss//gfs-g4-anl-files/'\n",
     "dt = datetime(2018, 1, 4, 12)\n",
     "ncss = NCSS('{}{dt:%Y%m}/{dt:%Y%m%d}/gfsanl_4_{dt:%Y%m%d}'\n",
     "            '_{dt:%H}00_000.grb2'.format(base_url, dt=dt))\n",

--- a/pages/gallery/Smoothing_Contours.ipynb
+++ b/pages/gallery/Smoothing_Contours.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "dt = datetime(2016, 4, 16, 18)\n",
-    "base_url = 'https://www.ncei.noaa.gov/thredds/ncss/grid/namanl/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/ncss//namanl/'\n",
     "ncss = NCSS('{}{dt:%Y%m}/{dt:%Y%m%d}/namanl_218_{dt:%Y%m%d}_'\n",
     "            '{dt:%H}00_000.grb'.format(base_url, dt=dt))\n",
     "\n",

--- a/pages/gallery/declarative_500_hPa.ipynb
+++ b/pages/gallery/declarative_500_hPa.ipynb
@@ -27,7 +27,7 @@
     "date = datetime(2012, 10, 31, 12)\n",
     "\n",
     "# Open dataset from NCEI\n",
-    "ds = xr.open_dataset('https://www.ncei.noaa.gov/thredds/dodsC/'\n",
+    "ds = xr.open_dataset('https://www.ncdc.noaa.gov/thredds/dodsC/'\n",
     "                     f'gfs-g4-anl-files/{date:%Y%m}/{date:%Y%m%d}/'\n",
     "                     f'gfsanl_4_{date:%Y%m%d}_{date:%H}00_000.grb2'\n",
     "                     ).metpy.parse_cf()\n",

--- a/pages/gallery/miller_composite.ipynb
+++ b/pages/gallery/miller_composite.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_url = 'https://www.ncei.noaa.gov/thredds/ncss/grid/namanl/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/ncss//namanl/'\n",
     "dt = datetime(2011, 4, 27)\n",
     "ncss = NCSS('{}{dt:%Y%m}/{dt:%Y%m%d}/namanl_218_{dt:%Y%m%d}_'\n",
     "            '1800_000.grb'.format(base_url, dt=dt))\n",

--- a/pages/gallery/xarray_500hPa_map.ipynb
+++ b/pages/gallery/xarray_500hPa_map.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "# Set year, month, day, and hour values as variables to make it\n",
     "# easier to change dates for a case study\n",
-    "base_url = 'https://www.ncei.noaa.gov/thredds/dodsC/namanl/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/dodsC/namanl/'\n",
     "dt = datetime(2016, 4, 16, 18)\n",
     "data = xr.open_dataset('{}{dt:%Y%m}/{dt:%Y%m%d}/namanl_218_{dt:%Y%m%d}_'\n",
     "                       '{dt:%H}00_000.grb'.format(base_url, dt=dt),\n",

--- a/pages/workshop/MetPy_Advanced/QG Analysis.ipynb
+++ b/pages/workshop/MetPy_Advanced/QG Analysis.ipynb
@@ -79,11 +79,11 @@
     "\n",
     "Let's go ahead and use the NARR Analysis data to investigate the past case we identified (The Storm of the Century).\n",
     "\n",
-    "https://www.ncei.noaa.gov/thredds/catalog/narr-a-files/199303/19930313/catalog.html?dataset=narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb\n",
+    "https://www.ncdc.noaa.gov/thredds/catalog/narr-a-files/199303/19930313/catalog.html?dataset=narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb\n",
     "\n",
     "And we will use a python package called Siphon to read this data through the NetCDFSubset (NetCDFServer) link.\n",
     "\n",
-    "https://www.ncei.noaa.gov/thredds/ncss/grid/narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb/dataset.html\n",
+    "https://www.ncdc.noaa.gov/thredds/ncss//narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb/dataset.html\n",
     "\n",
     "First we can set out date using the datetime module"
    ]
@@ -117,7 +117,7 @@
    "outputs": [],
    "source": [
     "# Read NARR Data from THREDDS server\n",
-    "base_url = 'https://www.ncei.noaa.gov/thredds/catalog/narr-a-files/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/catalog/narr-a-files/'\n",
     "\n",
     "# Programmatically generate the URL to the day of data we want\n",
     "cat = TDSCatalog(f'{base_url}{dt:%Y%m}/{dt:%Y%m%d}/catalog.xml')\n",

--- a/pages/workshop/MetPy_Case_Study/MetPy Case Study.ipynb
+++ b/pages/workshop/MetPy_Case_Study/MetPy Case Study.ipynb
@@ -142,11 +142,11 @@
     "**Choosing our data source**\n",
     "Let's go ahead and use the NARR Analysis data to investigate the past case we identified (The Storm of the Century).\n",
     "\n",
-    "https://www.ncei.noaa.gov/thredds/catalog/narr-a-files/199303/19930313/catalog.html?dataset=narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb\n",
+    "https://www.ncdc.noaa.gov/thredds/catalog/narr-a-files/199303/19930313/catalog.html?dataset=narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb\n",
     "\n",
     "And we will use a python package called Siphon to read this data through the NetCDFSubset (NetCDFServer) link.\n",
     "\n",
-    "https://www.ncei.noaa.gov/thredds/ncss/grid/narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb/dataset.html"
+    "https://www.ncdc.noaa.gov/thredds/ncss//narr-a-files/199303/19930313/narr-a_221_19930313_0000_000.grb/dataset.html"
    ]
   },
   {
@@ -171,7 +171,7 @@
    "outputs": [],
    "source": [
     "# Read NARR Data from THREDDS server\n",
-    "base_url = 'https://www.ncei.noaa.gov/thredds/catalog/narr-a-files/'\n",
+    "base_url = 'https://www.ncdc.noaa.gov/thredds/catalog/narr-a-files/'\n",
     "\n",
     "# Programmatically generate the URL to the day of data we want\n",
     "cat = TDSCatalog(f'{base_url}{dt:%Y%m}/{dt:%Y%m%d}/catalog.xml')\n",


### PR DESCRIPTION
Replace the old `ncei.noaa.gov` TDS URLs I found with their new `ncdc.noaa.gov` counterparts as described in (and closes) #81. Not sure if this is the preferred workflow for `python-training` or if anything else needs to change to squeeze this in. Let me know!