### PR TITLE
Update LOGO_URL

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -331,7 +331,7 @@ COMPILERS = {
 # Nikola supports logo display.  If you have one, you can put the URL here.
 # Final output is <img src="LOGO_URL" id="logo" alt="BLOG_TITLE">.
 # The URL may be relative to the site root.
-LOGO_URL = 'https://docs.unidata.ucar.edu/images/logos/unidata_logo_rgb_sm.png'
+LOGO_URL = 'https://www.unidata.ucar.edu/images/logos/unidata_logo_rgb_sm.png'
 
 # If you want to hide the title of your website (for example, if your logo
 # already contains the text), set this to False.


### PR DESCRIPTION
Original LOGO_URL was linking to docs.unidata.ucar.edu, needed to update to main hosted logo. Closes #98