### PR TITLE
Fixing Typos in Training Material

### DIFF
--- a/pages/workshop/Pythonic_Data_Analysis/Pythonic Data Analysis.ipynb
+++ b/pages/workshop/Pythonic_Data_Analysis/Pythonic Data Analysis.ipynb
@@ -502,8 +502,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def arg_func(*argv):  \n",
-    "    for arg in argv:  \n",
+    "def arg_func(*args):  \n",
+    "    for arg in args:  \n",
     "        print (arg) \n",
     "    \n",
     "arg_func('Welcome', 'to', 'the', 'Python', 'Workshop')  "

--- a/pages/workshop/Skew_T/SkewT and Hodograph.ipynb
+++ b/pages/workshop/Skew_T/SkewT and Hodograph.ipynb
@@ -219,7 +219,7 @@
    "outputs": [],
    "source": [
     "# Plot a isotherm using axvline (axis vertical line)\n",
-    "skew.ax.axvline([0] * units.degC, color='cyan', linestyle='--')\n",
+    "skew.ax.axvline(0 * units.degC, color='cyan', linestyle='--')\n",
     "\n",
     "# Redisplay the figure\n",
     "fig"


### PR DESCRIPTION
- Closes #71 
   - Removed brackets in isotherm plot to eliminate list
- Addresses part of issue #78 
   - Changed argv to args in Example 5 (Also included in other pull request related to Issue 78)