### PR TITLE
Fix SkewT_Example.ipynb

### DIFF
--- a/pages/gallery/SkewT_Example.ipynb
+++ b/pages/gallery/SkewT_Example.ipynb
@@ -140,7 +140,7 @@
     "                       alpha=0.25, color='orangered')\n",
     "skew.plot_moist_adiabats(t0=np.arange(233, 400, 5) * units.K,\n",
     "                         alpha=0.25, color='tab:green')\n",
-    "skew.plot_mixing_lines(p=np.arange(1000, 99, -20) * units.hPa,\n",
+    "skew.plot_mixing_lines(pressure=np.arange(1000, 99, -20) * units.hPa,\n",
     "                       linestyle='dotted', color='tab:blue')\n",
     "\n",
     "# Add some descriptive titles\n",


### PR DESCRIPTION
Example doesn't work as provided in MetPy 1.6.3
The keyword in plot_mixing_lines() should be "pressure=", not "p="